### PR TITLE
Excelファイルの転送時に意図せず .0 が付与されてしまう

### DIFF
--- a/src/main/java/org/embulk/parser/poi_excel/visitor/embulk/StringCellVisitor.java
+++ b/src/main/java/org/embulk/parser/poi_excel/visitor/embulk/StringCellVisitor.java
@@ -34,6 +34,7 @@ public class StringCellVisitor extends CellVisitor {
 		}
 
 		String s = BigDecimal.valueOf(value).toPlainString();
+		// MEMO: BigDecimalを使用して数値を変換する際、桁数によって末尾に.0が付加されることがあるため削除する
 		if (s.endsWith(".0")) {
 				return s.substring(0, s.length() - 2);
 		}

--- a/src/main/java/org/embulk/parser/poi_excel/visitor/embulk/StringCellVisitor.java
+++ b/src/main/java/org/embulk/parser/poi_excel/visitor/embulk/StringCellVisitor.java
@@ -33,7 +33,11 @@ public class StringCellVisitor extends CellVisitor {
 			}
 		}
 
-		return BigDecimal.valueOf(value).toPlainString();
+		String s = BigDecimal.valueOf(value).toPlainString();
+		if (s.endsWith(".0")) {
+				return s.substring(0, s.length() - 2);
+		}
+		return s;
 	}
 
 	protected String getNumericFormat(Column column) {


### PR DESCRIPTION
https://github.com/primenumber-dev/n-transfer-ui/issues/23049 の対応
BigDecimalを利用すると桁数によって .0 が付与されるので削除する